### PR TITLE
Resources bug

### DIFF
--- a/AzureResourceInventory.ps1
+++ b/AzureResourceInventory.ps1
@@ -739,7 +739,7 @@ param ($TenantID, [switch]$SecurityCenter, $SubscriptionID, $Appid, $Secret, $Re
 
                 $DrawRun.Dispose()
 
-            } -ArgumentList $PSScriptRoot, $Subscriptions, ($Resources | ConvertTo-Json -Depth 50), $Advisories, $DDFile, $RunOnline, $Repo, $RawRepo   | Out-Null
+            } -ArgumentList $PSScriptRoot, $Subscriptions, ($Resources | ConvertTo-Json -Depth 100), $Advisories, $DDFile, $RunOnline, $Repo, $RawRepo   | Out-Null
         }
 
         <######################################################### VISIO DIAGRAM JOB ######################################################################>
@@ -890,7 +890,7 @@ param ($TenantID, [switch]$SecurityCenter, $SubscriptionID, $Appid, $Secret, $Re
 
             $SubResult
 
-        } -ArgumentList $PSScriptRoot, $Subscriptions, ($Resources | ConvertTo-Json -Depth 50), 'Processing' , $File, $RunOnline, $RawRepo | Out-Null
+        } -ArgumentList $PSScriptRoot, $Subscriptions, ($Resources | ConvertTo-Json -Depth 100), 'Processing' , $File, $RunOnline, $RawRepo | Out-Null
 
         <######################################################### RESOURCE GROUP JOB ######################################################################>
 
@@ -986,7 +986,7 @@ param ($TenantID, [switch]$SecurityCenter, $SubscriptionID, $Appid, $Secret, $Re
                     }
 
                 $Hashtable
-                } -ArgumentList $null, $PSScriptRoot, $Subscriptions, $InTag, ($Resource | ConvertTo-Json -Depth 50), 'Processing', $null, $null, $null, $RunOnline, $Repo, $RawRepo | Out-Null                    
+                } -ArgumentList $null, $PSScriptRoot, $Subscriptions, $InTag, ($Resource | ConvertTo-Json -Depth 100), 'Processing', $null, $null, $null, $RunOnline, $Repo, $RawRepo | Out-Null                    
                 $Limit = $Limit + 5000   
             }
 

--- a/AzureResourceInventory.ps1
+++ b/AzureResourceInventory.ps1
@@ -371,6 +371,15 @@ param ($TenantID, [switch]$SecurityCenter, $SubscriptionID, $Appid, $Secret, $Re
                 write-host ""
                 $Global:DefaultPath = "$HOME/AzureResourceInventory/"
                 $Global:Subscriptions = Get-AzSubscription -ErrorAction SilentlyContinue | Where-Object {$_.State -ne 'Disabled'}
+
+                if ($SubscriptionID) {
+                    if($SubscriptionID.count -gt 1) {
+                        $Global:Subscriptions = $Global:Subscriptions | Where-Object { $_.Id -in $SubscriptionID }
+                    }
+                    else {
+                        $Global:Subscriptions = $Global:Subscriptions | Where-Object { $_.Id -eq $SubscriptionID }
+                    }
+                }
             }
             else
             {

--- a/AzureResourceInventory.ps1
+++ b/AzureResourceInventory.ps1
@@ -436,7 +436,7 @@ param ($TenantID, [switch]$SecurityCenter, $SubscriptionID, $Appid, $Secret, $Re
                 Write-Debug ('Extracting Resources from Subscription: '+$SubscriptionID+'. And from Resource Group: '+$ResourceGroup)
 
                 $GraphQuery = "resources | where resourceGroup == '$ResourceGroup' and strlen(properties.definition.actions) < 123000 | summarize count()"
-                $EnvSize = Search-AzGraph -Query $GraphQuery -Subscription $Subscri -Debug:$false
+                $EnvSize = Search-AzGraph -Query $GraphQuery -Subscription $Subscriptions.Id -Debug:$false
                 $EnvSizeNum = $EnvSize.data.'count_'
 
                 if ($EnvSizeNum -ge 1) {
@@ -447,7 +447,7 @@ param ($TenantID, [switch]$SecurityCenter, $SubscriptionID, $Appid, $Secret, $Re
 
                     while ($Looper -lt $Loop) {
                         $GraphQuery = "resources | where resourceGroup == '$ResourceGroup' and strlen(properties.definition.actions) < 123000 | project id,name,type,tenantId,kind,location,resourceGroup,subscriptionId,managedBy,sku,plan,properties,identity,zones,extendedLocation$($GraphQueryTags) | order by id asc"
-                        $Resource = Search-AzGraph -Query $GraphQuery -Subscription $Subscri -skip $Limit -first 1000 -Debug:$false
+                        $Resource = Search-AzGraph -Query $GraphQuery -Subscription $Subscriptions.Id -skip $Limit -first 1000 -Debug:$false
 
                         $Global:Resources += $Resource.data
                         Start-Sleep 2
@@ -462,7 +462,7 @@ param ($TenantID, [switch]$SecurityCenter, $SubscriptionID, $Appid, $Secret, $Re
             {
                 Write-Debug ('Extracting Resources from Subscription: '+$SubscriptionID+'.')
                 $GraphQuery = "resources | where strlen(properties.definition.actions) < 123000 | summarize count()"
-                $EnvSize = Search-AzGraph -Query $GraphQuery -Subscription $Subscri -Debug:$false
+                $EnvSize = Search-AzGraph -Query $GraphQuery -Subscription $Subscriptions.Id -Debug:$false
                 $EnvSizeNum = $EnvSize.data.'count_'
 
                 if ($EnvSizeNum -ge 1) {
@@ -473,7 +473,7 @@ param ($TenantID, [switch]$SecurityCenter, $SubscriptionID, $Appid, $Secret, $Re
 
                     while ($Looper -lt $Loop) {
                         $GraphQuery = "resources | where strlen(properties.definition.actions) < 123000 | project id,name,type,tenantId,kind,location,resourceGroup,subscriptionId,managedBy,sku,plan,properties,identity,zones,extendedLocation$($GraphQueryTags) | order by id asc"
-                        $Resource = Search-AzGraph -Query $GraphQuery -Subscription $Subscri -skip $Limit -first 1000 -Debug:$false
+                        $Resource = Search-AzGraph -Query $GraphQuery -Subscription $Subscriptions.Id -skip $Limit -first 1000 -Debug:$false
 
                         $Global:Resources += $Resource.data
                         Start-Sleep 2
@@ -487,7 +487,7 @@ param ($TenantID, [switch]$SecurityCenter, $SubscriptionID, $Appid, $Secret, $Re
         else 
             {
                 $GraphQuery = "resources | where strlen(properties.definition.actions) < 123000 | summarize count()"
-                $EnvSize = Search-AzGraph -Query $GraphQuery -Subscription $Subscri -Debug:$false
+                $EnvSize = Search-AzGraph -Query $GraphQuery -Subscription $Subscriptions.Id -Debug:$false
                 $EnvSizeNum = $EnvSize.data.'count_'
 
                 if ($EnvSizeNum -ge 1) {
@@ -498,7 +498,7 @@ param ($TenantID, [switch]$SecurityCenter, $SubscriptionID, $Appid, $Secret, $Re
 
                     while ($Looper -lt $Loop) {
                         $GraphQuery = "resources | where strlen(properties.definition.actions) < 123000 | project id,name,type,tenantId,kind,location,resourceGroup,subscriptionId,managedBy,sku,plan,properties,identity,zones,extendedLocation$($GraphQueryTags) | order by id asc"
-                        $Resource = Search-AzGraph -Query $GraphQuery -Subscription $Subscri -skip $Limit -first 1000 -Debug:$false
+                        $Resource = Search-AzGraph -Query $GraphQuery -Subscription $Subscriptions.Id -skip $Limit -first 1000 -Debug:$false
 
                         $Global:Resources += $Resource.data
                         Start-Sleep 2


### PR DESCRIPTION
Let's go...

- The variable $Global:subscri is null on the first execution of the script, causing a slowdown in the load of resources even if filtered by a single subscription. In Cloud Shell, loading all resources from all subscriptions can cause the session to crash.
- During resources serialization, resources with property depth greater than 50 were identified. I increased this to the maximum value (100). 
- In Cloud Shell, the script is not applying the filter by subscription causing the session to drop in some scenarios and the impossibility of generating reports for a single subscription.