### PR TITLE
Fix wrongly displayed annual savings.

### DIFF
--- a/Extras/Advisory.ps1
+++ b/Extras/Advisory.ps1
@@ -41,7 +41,7 @@ If ($Task -eq 'Processing')
                         #'Score'                  = $data.extendedproperties.score;
                         'Problem'                = $data.shortDescription.problem;
                         'Savings Currency'       = $SavingsCurrency;
-                        'Annual Savings'         = $Savings;
+                        'Annual Savings'         = "=$Savings";
                         'Savings Region'         = $data.extendedProperties.location;   
                         'Current SKU'            = $data.extendedProperties.currentSku;
                         'Target SKU'             = $data.extendedProperties.targetSku


### PR DESCRIPTION
The problem in the current version is that the annual cost savings are displayed wrongly in the Excel "Advisory"-sheet. </br> The issue occurs, when there are any decimal places present in the recommendations. So far Excel would've interpreted the decimal places as non-decimal-places. 

In order to prevent this the annual savings are set to `"=$Savings"` instead of `$Savings`. 