### PR TITLE
Unify headers and values in tables containing TLS version. 

### DIFF
--- a/Extras/Advisory.ps1
+++ b/Extras/Advisory.ps1
@@ -41,7 +41,7 @@ If ($Task -eq 'Processing')
                         #'Score'                  = $data.extendedproperties.score;
                         'Problem'                = $data.shortDescription.problem;
                         'Savings Currency'       = $SavingsCurrency;
-                        'Annual Savings'         = $Savings;
+                        'Annual Savings'         = "=$Savings";
                         'Savings Region'         = $data.extendedProperties.location;   
                         'Current SKU'            = $data.extendedProperties.currentSku;
                         'Target SKU'             = $data.extendedProperties.targetSku

--- a/Modules/Data/MariaDB.ps1
+++ b/Modules/Data/MariaDB.ps1
@@ -58,7 +58,7 @@ If ($Task -eq 'Processing') {
                             'Public Network Access'     = $data.publicNetworkAccess;
                             'Admin Login'               = $data.administratorLogin;
                             'Infrastructure Encryption' = $data.InfrastructureEncryption;
-                            'Minimal Tls Version'       = $data.minimalTlsVersion;
+                            'Minimal Tls Version'       = "$($data.minimalTlsVersion -Replace '_', '.' -Replace 'tls', 'TLS')";
                             'State'                     = $data.userVisibleState;
                             'Replica Capacity'          = $data.replicaCapacity;
                             'Replication Role'          = $data.replicationRole;

--- a/Modules/Data/MariaDB.ps1
+++ b/Modules/Data/MariaDB.ps1
@@ -58,7 +58,7 @@ If ($Task -eq 'Processing') {
                             'Public Network Access'     = $data.publicNetworkAccess;
                             'Admin Login'               = $data.administratorLogin;
                             'Infrastructure Encryption' = $data.InfrastructureEncryption;
-                            'Minimal Tls Version'       = "$($data.minimalTlsVersion -Replace '_', '.' -Replace 'tls', 'TLS')";
+                            'Minimum TLS Version'       = "$($data.minimalTlsVersion -Replace '_', '.' -Replace 'tls', 'TLS')";
                             'State'                     = $data.userVisibleState;
                             'Replica Capacity'          = $data.replicaCapacity;
                             'Replication Role'          = $data.replicationRole;
@@ -111,7 +111,7 @@ Else {
         $Exc.Add('Public Network Access')
         $Exc.Add('Admin Login')
         $Exc.Add('Infrastructure Encryption')
-        $Exc.Add('Minimal Tls Version')
+        $Exc.Add('Minimum TLS Version')
         $Exc.Add('State')
         $Exc.Add('Replica Capacity')
         $Exc.Add('Replication Role')

--- a/Modules/Data/MySQL.ps1
+++ b/Modules/Data/MySQL.ps1
@@ -49,7 +49,7 @@ If ($Task -eq 'Processing') {
                             'SKU Family'                = $sku.family;
                             'Tier'                      = $sku.tier;
                             'Capacity'                  = $sku.capacity;
-                            'MySQL Version'             = $data.version;
+                            'MySQL Version'             = "=$($data.version)";
                             'Private Endpoint'          = $PVTENDP;
                             'Backup Retention Days'     = $data.storageProfile.backupRetentionDays;
                             'Geo-Redundant Backup'      = $data.storageProfile.geoRedundantBackup;
@@ -58,7 +58,7 @@ If ($Task -eq 'Processing') {
                             'Public Network Access'     = $data.publicNetworkAccess;
                             'Admin Login'               = $data.administratorLogin;
                             'Infrastructure Encryption' = $data.InfrastructureEncryption;
-                            'Minimal Tls Version'       = $data.minimalTlsVersion;
+                            'Minimum TLS Version'       = "$($data.minimalTlsVersion -Replace '_', '.' -Replace 'tls', 'TLS ')";
                             'State'                     = $data.userVisibleState;
                             'Replica Capacity'          = $data.replicaCapacity;
                             'Replication Role'          = $data.replicationRole;
@@ -111,7 +111,7 @@ Else {
         $Exc.Add('Public Network Access')
         $Exc.Add('Admin Login')
         $Exc.Add('Infrastructure Encryption')
-        $Exc.Add('Minimal Tls Version')
+        $Exc.Add('Minimum TLS Version')
         $Exc.Add('State')
         $Exc.Add('Replica Capacity')
         $Exc.Add('Replication Role')

--- a/Modules/Data/POSTGRE.ps1
+++ b/Modules/Data/POSTGRE.ps1
@@ -58,12 +58,12 @@ If ($Task -eq 'Processing') {
                             'Public Network Access'     = $data.publicNetworkAccess;
                             'Admin Login'               = $data.administratorLogin;
                             'Infrastructure Encryption' = $data.InfrastructureEncryption;
-                            'Minimal Tls Version'       = $data.minimalTlsVersion;
+                            'Minimum TLS Version'       = "$($data.minimalTlsVersion -Replace '_', '.' -Replace 'tls', 'TLS')";
                             'State'                     = $data.userVisibleState;
                             'Replica Capacity'          = $data.replicaCapacity;
                             'Replication Role'          = $data.replicationRole;
                             'BYOK Enforcement'          = $data.byokEnforcement;
-                            'ssl Enforcement'           = $data.sslEnforcement;
+                            'SSL Enforcement'           = $data.sslEnforcement;
                             'Resource U'                = $ResUCount;
                             'Tag Name'                  = [string]$Tag.Name;
                             'Tag Value'                 = [string]$Tag.Value
@@ -112,7 +112,7 @@ Else {
         $Exc.Add('Public Network Access')
         $Exc.Add('Admin Login')
         $Exc.Add('Infrastructure Encryption')
-        $Exc.Add('Minimal Tls Version')
+        $Exc.Add('Minimum TLS Version')
         $Exc.Add('State')
         $Exc.Add('Replica Capacity')
         $Exc.Add('Replication Role')

--- a/Modules/Data/RedisCache.ps1
+++ b/Modules/Data/RedisCache.ps1
@@ -41,7 +41,7 @@ If ($Task -eq 'Processing') {
                 $data = $1.PROPERTIES
                 $PvtEndP = $data.privateEndpointConnections.properties.privateEndpoint.id.split('/')[8]
                 if ($1.ZONES) { $Zones = $1.ZONES }else { $Zones = 'Not Configured' }
-                if ([string]::IsNullOrEmpty($data.minimumTlsVersion)){$MinTLS = 'Default'}Else{$MinTLS = $data.minimumTlsVersion}
+                if ([string]::IsNullOrEmpty($data.minimumTlsVersion)){$MinTLS = 'Default'}Else{$MinTLS = "TLS $($data.minimumTlsVersion)"}
                 $Tags = if(![string]::IsNullOrEmpty($1.tags.psobject.properties)){$1.tags.psobject.properties}else{'0'}
                     foreach ($Tag in $Tags) {
                         $obj = @{
@@ -56,7 +56,7 @@ If ($Task -eq 'Processing') {
                             'FQDN'                  = $data.hostName;
                             'Port'                  = $data.port;
                             'Enable Non SSL Port'   = $data.enableNonSslPort;
-                            'Minimum Tls Version'   = $MinTLS;
+                            'Minimum TLS Version'   = $MinTLS;
                             'SSL Port'              = $data.sslPort;
                             'Private Endpoint'      = $PvtEndP;
                             'Sku'                   = $data.sku.name;
@@ -109,7 +109,7 @@ Else {
         $Exc.Add('FQDN')                    
         $Exc.Add('Port')                    
         $Exc.Add('Enable Non SSL Port')
-        $Exc.Add('Minimum Tls Version')         
+        $Exc.Add('Minimum TLS Version')         
         $Exc.Add('SSL Port')   
         $Exc.Add('Private Endpoint')             
         $Exc.Add('Sku')                     

--- a/Modules/Infrastructure/AppGW.ps1
+++ b/Modules/Infrastructure/AppGW.ps1
@@ -46,7 +46,7 @@ If ($Task -eq 'Processing') {
                             'Location'              = $1.LOCATION;
                             'State'                 = $data.OperationalState;
                             'WAF Enabled'           = $WAF;
-                            'Minimum SSL Protocol'  = $PROT;
+                            'Minimum TLS Version'   = "$($PROT -Replace '_', '.' -Replace 'v', ' ' -Replace 'tls', 'TLS')";
                             'Autoscale Min Capacity'= $MinCap;
                             'Autoscale Max Capacity'= $MaxCap;
                             'SKU Name'              = $data.sku.tier;
@@ -88,7 +88,7 @@ Else {
         $Exc.Add('Location')
         $Exc.Add('State')
         $Exc.Add('WAF Enabled')
-        $Exc.Add('Minimum SSL Protocol')
+        $Exc.Add('Minimum TLS Version')
         $Exc.Add('Autoscale Min Capacity')
         $Exc.Add('Autoscale Max Capacity')
         $Exc.Add('SKU Name')

--- a/Modules/Storage/StorageAcc.ps1
+++ b/Modules/Storage/StorageAcc.ps1
@@ -52,7 +52,7 @@ If ($Task -eq 'Processing') {
                             'Tier'                                  = $1.sku.tier;
                             'Supports HTTPs Traffic Only'           = $data.supportsHttpsTrafficOnly;
                             'Allow Blob Public Access'              = if ($data.allowBlobPublicAccess -eq $false) { $false }else { $true };
-                            'TLS Version'                           = $TLSv;
+                            'Minimum TLS Version'                   = $TLSv;
                             'Identity-based access for file shares' = if ($data.azureFilesIdentityBasedAuthentication.directoryServiceOptions -eq 'None') { $false }elseif ($null -eq $data.azureFilesIdentityBasedAuthentication.directoryServiceOptions) { $false }else { $true };
                             'Access Tier'                           = $data.accessTier;
                             'Primary Location'                      = $data.primaryLocation;
@@ -103,7 +103,7 @@ Else {
         $Exc.Add('Tier')
         $Exc.Add('Supports HTTPS Traffic Only')
         $Exc.Add('Allow Blob Public Access')
-        $Exc.Add('TLS Version')
+        $Exc.Add('Minumum TLS Version')
         $Exc.Add('Identity-based access for file shares')
         $Exc.Add('Access Tier')
         $Exc.Add('Primary Location')


### PR DESCRIPTION
So far ARI did use inconsistent headers and values across different resource Types, e.g. for the headers the following version were found:
- TLS Version
- Minimum TLS Version
- Minimum Tls Version
- Minimal Tls Version

They have all been changed to the uniform version "Minimum TLS Version". 

Further the values received were sometimes being given as "TLS1_1", "tlsv1_1", "TLS 1.2", ...  
An attempt to unify these is made by using the replace-method.