### PR TITLE
Fix: compatibility with WSL and Powershell Unix for draw.io diagram

### DIFF
--- a/AzureResourceInventory.ps1
+++ b/AzureResourceInventory.ps1
@@ -759,7 +759,7 @@ param ($TenantID,
                     $ModuSeq = (New-Object System.Net.WebClient).DownloadString($($args[7]) + '/Extras/DrawIODiagram.ps1')
                 }
                 Else {
-                    $ModuSeq0 = New-Object System.IO.StreamReader($($args[0]) + '\Extras\DrawIODiagram.ps1')
+                    $ModuSeq0 = New-Object System.IO.StreamReader($($args[0]) + '/Extras/DrawIODiagram.ps1')
                     $ModuSeq = $ModuSeq0.ReadToEnd()
                     $ModuSeq0.Dispose()  
                 }                  
@@ -1417,7 +1417,7 @@ Write-Host ('Excel file saved at: ') -NoNewline
 write-host $File -ForegroundColor Cyan
 Write-Host ''
 
-if($Global:PlatOS -eq 'PowerShell Desktop' -and $Diagram.IsPresent) {
+if(($Global:PlatOS -eq 'PowerShell Desktop' -or $Global:PlatOS -eq 'PowerShell Unix') -and $Diagram.IsPresent) {
     Write-Host ('Draw.io Diagram file saved at: ') -NoNewline
     write-host $DDFile -ForegroundColor Cyan
     Write-Host ''

--- a/AzureResourceInventory.ps1
+++ b/AzureResourceInventory.ps1
@@ -759,7 +759,14 @@ param ($TenantID,
                     $ModuSeq = (New-Object System.Net.WebClient).DownloadString($($args[7]) + '/Extras/DrawIODiagram.ps1')
                 }
                 Else {
-                    $ModuSeq0 = New-Object System.IO.StreamReader($($args[0]) + '/Extras/DrawIODiagram.ps1')
+                  if($($args[0]) -like '*\*')
+                      {
+                          $ModuSeq0 = New-Object System.IO.StreamReader($($args[0]) + '\Extras\DrawIODiagram.ps1')
+                      }
+                  else 
+                      {
+                          $ModuSeq0 = New-Object System.IO.StreamReader($($args[0]) + '/Extras/DrawIODiagram.ps1')
+                      }
                     $ModuSeq = $ModuSeq0.ReadToEnd()
                     $ModuSeq0.Dispose()  
                 }                  


### PR DESCRIPTION
While testing this script for a customer I was disappointed to see that it didn't generate the Draw.io diagram file when running in Powershell on Windows Subsystem for Linux. Seems to have been a small change i.e. folder slashes and a simple if change.

Tested this on Ubuntu for Windows 22.04 LTS.