### PR TITLE
Fix license type bug

### DIFF
--- a/Modules/Compute/VM.ps1
+++ b/Modules/Compute/VM.ps1
@@ -67,7 +67,7 @@ If ($Task -eq 'Processing')
                         'SLES_BYOS' { 'Azure Hybrid Benefit for SUSE' }
                         default { $data.licenseType }
                     }
-                    $Lic = if($data.licensetype){$data.licensetype}else{'None'}
+                    $Lic = if($Lic){$Lic}else{'None'}
                     $ext = ($vmexp | Where-Object { ($_.id -split "/")[8] -eq $1.name }).properties.Publisher
                     if ($null -ne $ext) 
                         {


### PR DESCRIPTION
License type translation didn't work because it referenced the original value instead of the modified value
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/ARI/pull/114)