### PR TITLE
Removed Redundant 'ConvertFrom-Json' Conversion

### DIFF
--- a/AzureResourceInventory.ps1
+++ b/AzureResourceInventory.ps1
@@ -586,7 +586,7 @@ param ($TenantID,
                         
                         $LocalResults += $QueryResult
                         while ($QueryResult.skip_token) {
-                            $QueryResult = az graph query -q $GraphQuery --subscriptions $FSubscri --skip-token $QueryResult.skip_token --first 1000 --output json --only-show-errors| ConvertFrom-Json
+                            $QueryResult = az graph query -q $GraphQuery --subscriptions $FSubscri --skip-token $QueryResult.skip_token --first 1000 --output json --only-show-errors
                             try
                                 {
                                     $QueryResult = $QueryResult | ConvertFrom-Json


### PR DESCRIPTION
Fixes issue reported in [#200](https://github.com/microsoft/ARI/issues/200#issuecomment-2220725360)

> | Conversion from JSON failed with error: Unexpected character encountered while parsing value: @. Path '', line
> | 0, position 0.
> ConvertFrom-Json: C:\3.1.34\ARI-main\AzureResourceInventory.ps1:596
> Line |
> 596 | … $QueryResult = $QueryResult | ConvertFrom-Json -AsHashtable
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/ARI/pull/202)