### PR TITLE
updating readme to fix broken automation howto link

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ If you want to automatically run ARI, there is a way to do it using Automation A
   <img src="images/Automation.png" width="600">
 </p>
 
-See the [Automation Guide](https://github.com/microsoft/ARI/blob/main/Docs/Automation.md) for implementation details.
+See the [Automation Guide](https://github.com/microsoft/ARI/blob/main/docs/Automation.md) for implementation details.
 
 ## 📝 Parameters Reference
 


### PR DESCRIPTION
I just changed the link that points to the automation documentation, to follow the new documentation folder name "docs" instead of the old "Docs"
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/ARI/pull/298)