### PR TITLE
Adding issue templates for bug reporting, feature requests and questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug]:"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+How can we reproduce this error? What were your input parameters? 
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment**
+On what kind of system were you running? When have you installed ARI?
+
+**Azure cloud special setting**
+Is the Environment specially configured(Government cloud, MFA login, etc.)
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Request]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question-.md
+++ b/.github/ISSUE_TEMPLATE/question-.md
@@ -1,0 +1,18 @@
+---
+name: 'Question '
+about: Have a question about the project?
+title: "[Question]:"
+labels: question
+assignees: ''
+
+---
+
+**Have a question about the project? Please write it down under!**
+
+You can format your question using Markdown styling, so it's easier to understand!
+
+**What version are you using?**
+The version you would be using or the version your question is about
+
+**Any other context information**
+Any additional information that might be helpful to answear your question


### PR DESCRIPTION
Added markdown templates that can be used as issue templates for bug reporting, feature requests and questions. Mostly to help users write more structured issues. This should be used as a base, and improved and extended based on experience. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/ARI/pull/316)