### PR TITLE
Fix typos in DEBUG messages throughout the codebase (#1)

### DIFF
--- a/Modules/Private/1.ExtractionFunctions/Get-ARIAPIResources.ps1
+++ b/Modules/Private/1.ExtractionFunctions/Get-ARIAPIResources.ps1
@@ -23,7 +23,7 @@ function Get-ARIAPIResources {
 
     try
         {
-            Write-Debug ((get-date -Format 'yyyy-MM-dd_HH_mm_ss')+' - '+'Adquiring Token')
+            Write-Debug ((get-date -Format 'yyyy-MM-dd_HH_mm_ss')+' - '+'Acquiring Token')
             $Token = Get-AzAccessToken -AsSecureString -InformationAction SilentlyContinue -WarningAction SilentlyContinue -Debug:$false
 
             $TokenData = $Token.Token | ConvertFrom-SecureString -AsPlainText
@@ -108,8 +108,8 @@ function Get-ARIAPIResources {
             }
             Start-Sleep -Milliseconds 200
 
-            #VM Reservation Recomentation
-            Write-Debug ((get-date -Format 'yyyy-MM-dd_HH_mm_ss')+' - '+'Getting VM Reservation Recomentation')
+            #VM Reservation Recommendation
+            Write-Debug ((get-date -Format 'yyyy-MM-dd_HH_mm_ss')+' - '+'Getting VM Reservation Recommendation')
             $url = ('https://' + $AzURL + '/subscriptions/' + $Sub + '/providers/Microsoft.Consumption/reservationRecommendations?api-version=2023-05-01')
             try {
                 $ReservationRecon = Invoke-RestMethod -Uri $url -Headers $header -Method GET

--- a/Modules/Public/PublicFunctions/Invoke-ARI.ps1
+++ b/Modules/Public/PublicFunctions/Invoke-ARI.ps1
@@ -166,11 +166,11 @@ Function Invoke-ARI {
         [switch]$DiagramFullEnvironment
         )
 
-    Write-Debug ((get-date -Format 'yyyy-MM-dd_HH_mm_ss')+' - '+'Debbuging Mode: On. ErrorActionPreference was set to "Continue", every error will be presented.')
+    Write-Debug ((get-date -Format 'yyyy-MM-dd_HH_mm_ss')+' - '+'Debugging Mode: On. ErrorActionPreference was set to "Continue", every error will be presented.')
 
     if ($DebugPreference -eq 'SilentlyContinue')
         {
-            Write-Host 'Debbuging Mode: ' -nonewline
+            Write-Host 'Debugging Mode: ' -nonewline
             Write-Host 'Off' -ForegroundColor Yellow
             Write-Host 'Use the parameter ' -nonewline
             Write-Host '-Debug' -nonewline -ForegroundColor Yellow


### PR DESCRIPTION
DEBUG messages include typo's that detract the attention from the actual message contents.

This was a good opportunity to test Copilot Agent.

**Copilot Agent PR description**

This PR fixes several spelling mistakes in DEBUG messages and related output text across the Azure Resource Inventory (ARI) codebase. The typos were causing unprofessional output when running ARI with debug logging enabled.

## Fixed Typos

The following spelling errors have been corrected:

1. **"Debbuging" → "Debugging"** in `Invoke-ARI.ps1`
   - Fixed in both `Write-Debug` statement and `Write-Host` output
   - Affects the debug mode status messages shown to users

2. **"Adquiring" → "Acquiring"** in `Get-ARIAPIResources.ps1`
   - Fixed in `Write-Debug` statement for token acquisition logging

3. **"Recomentation" → "Recommendation"** in `Get-ARIAPIResources.ps1`
   - Fixed in both comment and `Write-Debug` statement for VM reservation recommendations

## Impact

These fixes improve the professional appearance of debug output when users run:
```powershell
Invoke-ARI -Debug
```

The corrections ensure proper spelling in diagnostic messages, making the tool more polished and easier to read during troubleshooting sessions.

All changes are minimal and surgical - only the misspelled words were corrected with no functional changes to the code logic.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/ARI/pull/350)